### PR TITLE
Converted paths to lowercase for Linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Object files
+*.o
+
+# Linker output
+*.map
+*.dep
+
+# Executables
+*.exe
+*.elf

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ $(SRC_DIR)/lz77.S                 \
 $(SRC_DIR)/asmdata.S                      
 
 CPPFLAGS += -flto -Wno-deprecated \
--I../psyq/include 								\
--I$(INC_DIR)                  		\
+-I../psyq/include 				  \
+-I../nugget/psyq/include 		  \
+-I$(INC_DIR)                  	  \
 
 LDFLAGS += -L../psyq/lib -flto -Wno-deprecated
 LDFLAGS += -Wl,--start-group

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TYPE=exe
+TYPE=ps-exe
 
 TARGET = test
 

--- a/include/camera/camera.h
+++ b/include/camera/camera.h
@@ -13,7 +13,7 @@
 
 #include "global.h"
 
-#include "ACTOR\actors.h"
+#include "actor/actors.h"
 
 #define Camera_SetPosition(camera, x, y, z) ({ \
     (camera)->position.vx = x; \

--- a/include/global.h
+++ b/include/global.h
@@ -11,8 +11,6 @@
 /* global.h */
 #ifndef _GLOBAL_H
 #define _GLOBAL_H
-/* CD ROM LBAs */
-#include "../cdromdata.h"
 
 /* PSX Library Files */
 #include <memory.h>

--- a/include/global.h
+++ b/include/global.h
@@ -30,7 +30,7 @@
 #include <libsnd.h>
 
 #include <inline_n.h>
-#include <GTEMAC.h>
+#include <gtemac.h>
 
 extern u_long *DivideGT3( SVECTOR *v0, SVECTOR *v1, SVECTOR *v2, u_long *uv0, u_long *uv1, u_long
 *uv2, CVECTOR *rgb0, CVECTOR *rgb1, CVECTOR *rgb2, POLY_GT3 *s, u_long *ot, DIVPOLYGON3

--- a/include/model/agm.h
+++ b/include/model/agm.h
@@ -11,7 +11,7 @@
 #ifndef AGM_H
 #define AGM_H
 
-#include "SUBDIV.h"
+#include "subdiv.h"
 #include "global.h"
 #include "camera/camera.h"
 #include "model/clip.h"

--- a/include/model/sgm.h
+++ b/include/model/sgm.h
@@ -11,7 +11,7 @@
 #ifndef SGM_H
 #define SGM_H
 
-#include "SUBDIV.h"
+#include "subdiv.h"
 #include "global.h"
 //#include "camera.h"
 #include "model/clip.h"

--- a/src/actor/a_obj_grass.c
+++ b/src/actor/a_obj_grass.c
@@ -11,7 +11,7 @@
 #include "actor/a_obj_grass.h"
 #include "scene/scene.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 struct SGM2 * obj_grass_model;
 struct SGM2 * obj_grass_far_model;

--- a/src/actor/a_obj_grass_cut.c
+++ b/src/actor/a_obj_grass_cut.c
@@ -11,7 +11,7 @@
 #include "actor/a_obj_grass_cut.h"
 #include "scene/scene.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 #define GRASS_CUT_REGROW_SCALE 1024
 

--- a/src/actor/a_obj_syokudai.c
+++ b/src/actor/a_obj_syokudai.c
@@ -11,7 +11,7 @@
 #include "actor/a_obj_syokudai.h"
 #include "scene/scene.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 struct SGM2 * obj_syokudai_model;
 struct SGM2 * obj_flame_model;

--- a/src/actor/a_obj_tsubo.c
+++ b/src/actor/a_obj_tsubo.c
@@ -11,7 +11,7 @@
 #include "actor/a_obj_tsubo.h"
 #include "scene/scene.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 struct SGM2 * obj_tsubo_model;
 struct SGM2 * obj_tsubo_far_model;

--- a/src/actor/a_player.c
+++ b/src/actor/a_player.c
@@ -10,7 +10,7 @@
 
 #include "actor/a_player.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 #include "../../AGAME_PCDATA/player_new.agm.anm.h"
 

--- a/src/archive/arc.c
+++ b/src/archive/arc.c
@@ -8,7 +8,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. 
  */
 
-#include "archive/ARC.h"
+#include "archive/arc.h"
 
 
 void ARC_Decompress(unsigned long * dest, ARC_Header * src){

--- a/src/asmdata.S
+++ b/src/asmdata.S
@@ -45,7 +45,7 @@
 
 
 load_symbol:
-  .incbin "../AGAME_PCDATA/graphics/system/LOAD_SYMBOL.tim"
+  .incbin "../AGAME_PCDATA/graphics/system/LOAD_SYMBOL.TIM"
   .balign 16
 
 player_tim:

--- a/src/asmdata.S
+++ b/src/asmdata.S
@@ -11,11 +11,6 @@
 .section .data
         
   .global load_symbol
-  .global vab_hdata
-  .global vab_bdata
-	.global seq_data
-  /*.global test_tim
-  ;.global test_sgm*/
   .global player_tim
   .global player_agm
   .global player_anm
@@ -47,35 +42,14 @@
   .global test_image2_tim
   .global test_image3_tim
   .global test_image4_tim
-  .global test_obj_chara_sgm2
-  .global test_obj_chara_tim
 
 
 load_symbol:
-  .incbin "data/graphics/system/LOAD_SYMBOL.TIM"
+  .incbin "../AGAME_PCDATA/graphics/system/LOAD_SYMBOL.TIM"
   .balign 16
-
-vab_hdata:
-	.incbin "data/sound/ZOOT_V3.VH"
-  .balign 16
-
-vab_bdata:
-	.incbin "data/sound/ZOOT_V3.VB"
-  .balign 16
-
-seq_data:
-  .incbin "data/sound/ZOOT_ST6.SEQ"
-  .balign 16
-/*test_tim:
-;  .incbin "data/graphics/REPLACE_BLOCK.TIM"
-;  .balign 16
-;test_sgm:
-;  .incbin "data/graphics/test_player_model.sgm"
-;  .balign 16
-*/
 
 player_tim:
-  .incbin "data/graphics/player_area_composite.TIM"
+  .incbin "../AGAME_PCDATA/graphics/player_area_composite.tim"
   .balign 16
 
 player_agm:
@@ -91,16 +65,16 @@ sword_sg2:
   .balign 16
 
 scene_tim:
-  .incbin "data/graphics/replace_block-psnew2225.tim"
+  .incbin "../AGAME_PCDATA/graphics/replace_block-psnew2225.tim"
   .balign 16
 
 scene_col:
-  .incbin "data/graphics/TestRoom_C000-colbb-fixed-optimized.col2"
+  .incbin "../AGAME_PCDATA/graphics/TestRoom_C000-colbb-fixed-optimized.col2"
   .balign 16
 
 scene_room00_sg2:
   .incbin "../AGAME_PCDATA/Map/Test/room_000.sgm2"
-/*;  .incbin "../AGAME_PCDATA/TestRoom_C000-colbb-fixed.sgm2"*/
+  .balign 16
 
 scene_room01_sg2:
   .incbin "../AGAME_PCDATA/Map/Test/room_001.sgm2"
@@ -194,12 +168,4 @@ test_image3_tim:
   .balign 16
 test_image4_tim:
   .incbin "../AGAME_PCDATA/item_icons/bow-multi-pal.tim"
-  .balign 16
-  
-test_obj_chara_sgm2:
-  .incbin "../AGAME_PCDATA/test_obj_chara.sgm2"
-  .balign 16
-
-test_obj_chara_tim:
-  .incbin "../AGAME_PCDATA/test_obj_chara.tim"
   .balign 16

--- a/src/model/agm.c
+++ b/src/model/agm.c
@@ -10,8 +10,8 @@
 
 #include "model/agm.h"
 
-#include<inline_n.h>
-#include<GTEMAC.h>
+#include <inline_n.h>
+#include <gtemac.h>
 
 char compare_bit = 0;
 

--- a/src/model/sgm.c
+++ b/src/model/sgm.c
@@ -12,7 +12,7 @@
 
 #include <libgte.h>
 #include <inline_n.h>
-#include <GTEMAC.h>
+#include <gtemac.h>
 
 u_char subdiv_enable = 0;
 u_char subdiv_level0 = 1;

--- a/src/model/sgm2.c
+++ b/src/model/sgm2.c
@@ -10,8 +10,8 @@
 
 #include "model/sgm2.h"
 
-#include<inline_n.h>
-#include<GTEMAC.h>
+#include <inline_n.h>
+#include <gtemac.h>
 
 #define SGM2_SUBDIV_LV1 180
 #define SGM2_SUBDIV_LV2 80

--- a/src/particles/particles.c
+++ b/src/particles/particles.c
@@ -10,7 +10,7 @@
 
 #include "particles/particles.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 /*
 SVECTOR pos = { particle.x, particle.y particle.z };

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -10,7 +10,7 @@
 
 #include "scene/scene.h"
 
-#include "SPADSTK.h"
+#include "spadstk.h"
 
 #include "texture/texture.h"
 

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -78,10 +78,6 @@ extern unsigned long test_image2_tim[];
 extern unsigned long test_image3_tim[];
 extern unsigned long test_image4_tim[];
 
-extern unsigned long test_obj_chara_sgm2[];
-extern unsigned long test_obj_chara_tim[];
-
-
 /*SGM2_File * current_room = NULL; //
 SGM2_File * previous_room = NULL; /* Previous room rendering, if null, skip rendering
                                    * This is used in the transition between two rooms
@@ -590,8 +586,6 @@ void SceneLoad() {
   load_texture_pos((unsigned long)test_image2_tim, 64+(13*1), 256, FLAME_TEX_CLUT_X, FLAME_TEX_CLUT_Y+9);
   load_texture_pos((unsigned long)test_image3_tim, 64+(13*2), 256, FLAME_TEX_CLUT_X, FLAME_TEX_CLUT_Y+10);
   load_texture_pos((unsigned long)test_image4_tim, 64+(13*3), 256, FLAME_TEX_CLUT_X, FLAME_TEX_CLUT_Y+13);
-
-  load_texture_pos((unsigned long)test_obj_chara_tim, 128, 0, 512, 241);
 
   anim_tex_flame_src = (RECT) {FLAME_TEX_X_SRC, FLAME_TEX_Y_SRC, FLAME_TEX_W, FLAME_TEX_H};
   anim_tex_flame_dest = (RECT) {FLAME_TEX_X, FLAME_TEX_Y, FLAME_TEX_W, FLAME_TEX_H*2};


### PR DESCRIPTION
- Convert paths to includes to lowercase
- Use ps-exe instead of exe, to avoid having to edit nugget default files
- I think that's it :)